### PR TITLE
Working getNetwork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
         "@fontsource/inter": "^4.5.15",
-        "@gemwallet/api": "^2.2.0",
+        "@gemwallet/api": "^2.2.1",
         "@lottiefiles/react-lottie-player": "^3.5.3",
         "classnames": "^2.3.2",
         "framer-motion": "^10.11.6",
@@ -2064,9 +2064,9 @@
       "integrity": "sha512-FzleM9AxZQK2nqsTDtBiY0PMEVWvnKnuu2i09+p6DHvrHsuucoV2j0tmw+kAT3L4hvsLdAIDv6MdGehsPIdT+Q=="
     },
     "node_modules/@gemwallet/api": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@gemwallet/api/-/api-2.2.0.tgz",
-      "integrity": "sha512-3UbR34gUHsqSG7jV7uiJIzNwGK16cF9YN+K4SlNr1G/dYHZIqZ6NMoDH5v4qDxOORWyl1w3+LtAD5WbOU7WU5g=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@gemwallet/api/-/api-2.2.1.tgz",
+      "integrity": "sha512-/qW49CcpfQvtB/IIInkop3JywbabtvB0NZOIFcvPZP9nXZYYqP2n2RFaphvWV/gjRdmndefyfggmFk7XcmAk1Q=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -5086,9 +5086,9 @@
       "integrity": "sha512-FzleM9AxZQK2nqsTDtBiY0PMEVWvnKnuu2i09+p6DHvrHsuucoV2j0tmw+kAT3L4hvsLdAIDv6MdGehsPIdT+Q=="
     },
     "@gemwallet/api": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@gemwallet/api/-/api-2.2.0.tgz",
-      "integrity": "sha512-3UbR34gUHsqSG7jV7uiJIzNwGK16cF9YN+K4SlNr1G/dYHZIqZ6NMoDH5v4qDxOORWyl1w3+LtAD5WbOU7WU5g=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@gemwallet/api/-/api-2.2.1.tgz",
+      "integrity": "sha512-/qW49CcpfQvtB/IIInkop3JywbabtvB0NZOIFcvPZP9nXZYYqP2n2RFaphvWV/gjRdmndefyfggmFk7XcmAk1Q=="
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@fontsource/inter": "^4.5.15",
-    "@gemwallet/api": "^2.2.0",
+    "@gemwallet/api": "^2.2.1",
     "@lottiefiles/react-lottie-player": "^3.5.3",
     "classnames": "^2.3.2",
     "framer-motion": "^10.11.6",

--- a/src/shared/contexts/gemwallet-connection-context.tsx
+++ b/src/shared/contexts/gemwallet-connection-context.tsx
@@ -1,4 +1,4 @@
-import { isConnected } from "@gemwallet/api"
+import { getNetwork, isConnected } from "@gemwallet/api"
 import { useEffect, useState } from "react"
 import { contextFactory } from "../helpers"
 import {
@@ -24,11 +24,15 @@ export const GemWalletProvider = ({ children }: GemWalletProviderProps) => {
       }
       isConnected()
         .then((response) => {
+          console.log('isConnected', response);
           setHasGemWallet(response)
           // bug
-          // getNetwork()
-          //   .then((resp) => setNetwork(resp))
-          //   .catch((err) => console.error(`Can't load GemWallet network, ${err}`))
+          getNetwork()
+            .then((resp: any) => {
+              console.log('getNetwork', resp);
+              setNetwork(resp)
+            })
+            .catch((err) => console.error(`Can't load GemWallet network, ${err}`))
         })
         .catch((err) => console.error(err))
     }, 1000)


### PR DESCRIPTION
I have updated to the last version of API of GemWallet, and put a few `console.log`.
I actually do get the network.
Though I had to put a type as `any`, this is gonna be fixed soon in the next release.
Here is a screenshot of the response working:
<img width="1189" alt="Screenshot 2023-04-16 at 20 58 02" src="https://user-images.githubusercontent.com/7243879/232335566-52f0544f-cfd4-48c7-ad4e-61a2e6a4406d.png">

